### PR TITLE
ENH: Implementation of rectangle marker type named 'rect'

### DIFF
--- a/hyperspy/drawing/marker.py
+++ b/hyperspy/drawing/marker.py
@@ -27,7 +27,7 @@ class Marker(object):
     Attributes
     ----------
 
-    type : {'line','axvline','axhline','text','pointer'}
+    type : {'line','axvline','axhline','text','pointer','rect'}
         Select the type of markers
     orientation : {None,'v','h'}
         Orientation for lines. 'v' is vertical, 'h' is horizontal.
@@ -53,6 +53,7 @@ class Marker(object):
         For 'axhline': 'y1'
         For 'text': 'x1','y1','text'
         For 'pointer': 'x1','y1','size'. 'size' is optional
+        For 'rect': 'x1','y1','x2','y2'
 
     Example
     -------
@@ -75,6 +76,14 @@ class Marker(object):
     >>> im._plot.signal_plot.add_marker(m)
     >>> m.plot()
 
+    >>> im = signals.Image(np.zeros((100,100)))
+    >>> m = utils.plot.marker()
+    >>> m.type = 'rect'
+    >>> m.set_marker_properties(linewidth=4,color='red',ls='dotted')
+    >>> m.set_data(x1=20,x2=70,y1=20,y2=70)
+    >>> im.plot()
+    >>> im._plot.signal_plot.add_marker(m)
+    >>> m.plot()
 
     """
 
@@ -112,10 +121,14 @@ class Marker(object):
         elif value == 'pointer':
             lp['color'] = 'black'
             lp['linewidth'] = None
+        elif value == 'rect':
+            lp['color'] = 'black'
+            lp['fill'] = None
+            lp['linewidth'] = 1
         else:
             raise ValueError(
                 "`type` must be one of "
-                "{\'line\',\'axvline\',\'axhline\',\'text\',\'pointer\'}"
+                "{\'line\',\'axvline\',\'axhline\',\'text\',\'pointer\',\'rect\'}"
                 "but %s was given" % value)
         self._type = value
         self.marker_properties = lp
@@ -173,6 +186,13 @@ class Marker(object):
                 self.set_data(size=20)
                 data = self.data
             self.marker._sizes = [self.get_data_position('size')]
+
+        elif self.type == 'rect':
+            width = abs(self.get_data_position('x1') - self.get_data_position('x2'))
+            height = abs(self.get_data_position('y1') - self.get_data_position('y2'))
+            self.marker = self.ax.add_patch(plt.Rectangle(
+                (self.get_data_position('x1'), self.get_data_position('y1')),
+                width, height, **self.marker_properties))
 
         self.marker.set_animated(True)
         # To be discussed, done in Spectrum figure once.
@@ -261,6 +281,9 @@ class Marker(object):
             self.marker.set_offsets([self.get_data_position('x1'),
                                      self.get_data_position('y1')])
             self.marker._sizes = [self.get_data_position('size')]
+        elif self.type == 'rect':
+            self.marker.set_xdata([self.get_data_position('x1'),self.get_data_position('x2')])
+            self.marker.set_ydata([self.get_data_position('y1'),self.get_data_position('y2')])
         # To be discussed, done in SpectrumLine once.
         # try:
             # self.ax.figure.canvas.draw()

--- a/hyperspy/tests/drawing/test_marker_rect.ipynb
+++ b/hyperspy/tests/drawing/test_marker_rect.ipynb
@@ -1,0 +1,65 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:eb7446affb4368e4e6992b0c7eaed43125457a902824fa2c28541a61a228e0a7"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Create test image 100x100 pixels:\n",
+      "img = signals.Image(np.zeros((100,100)))\n",
+      "\n",
+      "# Add four line markers:\n",
+      "m1 = utils.plot.marker()\n",
+      "m2 = utils.plot.marker()\n",
+      "m3 = utils.plot.marker()\n",
+      "m4 = utils.plot.marker()\n",
+      "m1.type = 'line'\n",
+      "m2.type = 'line'\n",
+      "m3.type = 'line'\n",
+      "m4.type = 'line'\n",
+      "m1.set_marker_properties(color='red',linewidth=3)\n",
+      "m2.set_marker_properties(color='red',linewidth=3)\n",
+      "m3.set_marker_properties(color='red',linewidth=3)\n",
+      "m4.set_marker_properties(color='red',linewidth=3)\n",
+      "m1.set_data(x1=20,y1=20,x2=70,y2=20)\n",
+      "m2.set_data(x1=20,y1=20,x2=20,y2=70)\n",
+      "m3.set_data(x1=20,y1=70,x2=70,y2=70)\n",
+      "m4.set_data(x1=70,y1=20,x2=70,y2=70)\n",
+      "\n",
+      "# Add rectangle marker at same position:\n",
+      "m = utils.plot.marker()\n",
+      "m.type = 'rect'\n",
+      "m.set_marker_properties(linewidth=4,color='blue',ls='dotted')\n",
+      "m.set_data(x1=20,x2=70,y1=20,y2=70)\n",
+      "\n",
+      "# Plot image and add markers to img:\n",
+      "img.plot()\n",
+      "img._plot.signal_plot.add_marker(m)\n",
+      "img._plot.signal_plot.add_marker(m1)\n",
+      "img._plot.signal_plot.add_marker(m2)\n",
+      "img._plot.signal_plot.add_marker(m3)\n",
+      "img._plot.signal_plot.add_marker(m4)\n",
+      "\n",
+      "# Plot markers:\n",
+      "m.plot()\n",
+      "m1.plot()\n",
+      "m2.plot()\n",
+      "m3.plot()\n",
+      "m4.plot()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
Hi Pierre,

I've added a rectangle type to the marker class. It is of use to me, so perhaps it will be to others as well. I'll make a note of it in the upstream pull request for the marker class (https://github.com/hyperspy/hyperspy/pull/295)

Let me know if you think it needs any changes. Seems to be working for me with the following test code:

```
# Create test image 100x100 pixels:
img = signals.Image(np.zeros((100,100)))

# Add four line markers:
m1 = utils.plot.marker()
m2 = utils.plot.marker()
m3 = utils.plot.marker()
m4 = utils.plot.marker()
m1.type = 'line'
m2.type = 'line'
m3.type = 'line'
m4.type = 'line'
m1.set_marker_properties(color='red',linewidth=3)
m2.set_marker_properties(color='red',linewidth=3)
m3.set_marker_properties(color='red',linewidth=3)
m4.set_marker_properties(color='red',linewidth=3)
m1.set_data(x1=20,y1=20,x2=70,y2=20)
m2.set_data(x1=20,y1=20,x2=20,y2=70)
m3.set_data(x1=20,y1=70,x2=70,y2=70)
m4.set_data(x1=70,y1=20,x2=70,y2=70)

# Add rectangle marker at same position:
m = utils.plot.marker()
m.type = 'rect'
m.set_marker_properties(linewidth=4,color='blue',ls='dotted')
m.set_data(x1=20,x2=70,y1=20,y2=70)

# Plot image and add markers to img:
img.plot()
img._plot.signal_plot.add_marker(m)
img._plot.signal_plot.add_marker(m1)
img._plot.signal_plot.add_marker(m2)
img._plot.signal_plot.add_marker(m3)
img._plot.signal_plot.add_marker(m4)

# Plot markers:
m.plot()
m1.plot()
m2.plot()
m3.plot()
m4.plot()
```
